### PR TITLE
Sprint8 user registration624 viri

### DIFF
--- a/api/wwcodesvtools/api/helper_functions.py
+++ b/api/wwcodesvtools/api/helper_functions.py
@@ -2,6 +2,7 @@ from django.template.loader import get_template
 from django.core.mail import EmailMessage
 from django.conf import settings
 from smtplib import SMTPException
+from datetime import datetime, timedelta
 from django.core.validators import validate_email, ValidationError
 from pathlib import Path
 from api.models import User_Team, Role
@@ -49,3 +50,10 @@ def is_director_or_superuser(user_id, is_superuser):
     except Exception as e:
         logger.error(f'is_director_or_superuser: Error user not found : {e}')
         return False
+
+
+# Validate if the token/registration link is expired based on the date (last 14 digits of the token)
+# It's expired if it's been more than 72hrs
+def is_token_expired(self, registration_token):
+    token_datetime = datetime.strptime(registration_token[-14:], '%Y%m%d%H%M%S')
+    return (datetime.now() - timedelta(seconds=settings.REGISTRATION_LINK_EXPIRATION) > token_datetime)

--- a/api/wwcodesvtools/api/views/UserRegistrationView.py
+++ b/api/wwcodesvtools/api/views/UserRegistrationView.py
@@ -78,8 +78,8 @@ class UserRegistrationView(GenericAPIView):
             if (invitee.registration_token == request_token):
                 # email and token matched, check token expiration
                 if (not is_token_expired(self, request_token)):
-                    user_serializer = UserSerializer(data={'email': request_data['email'], 'username': request_data['email'],'first_name': request_data['first_name'],
-                                                                'last_name': request_data['last_name'], 'password': request_data['password']})
+                    user_serializer = UserSerializer(data={'email': request_data['email'], 'username': request_data['email'], 'first_name': request_data['first_name'],
+                                                           'last_name': request_data['last_name'], 'password': request_data['password']})
                     # if the token is not expired and all the fields are valid,
                     # create a new user, a new user-team-role and delete the invitee
                     if user_serializer.is_valid():

--- a/api/wwcodesvtools/api/views/UserRegistrationView.py
+++ b/api/wwcodesvtools/api/views/UserRegistrationView.py
@@ -1,40 +1,36 @@
-from django.contrib.auth.models import User
 from rest_framework.response import Response
 from rest_framework import status
-from api.models import RegistrationToken
-from api.serializers.UserRegistrationSerializer import UserRegistrationSerializer
+from api.models import Invitee, User_Team, Role
 from api.serializers.UserActivationSerializer import UserActivationSerializer
+from api.serializers.UserSerializer import UserSerializer
+from api.helper_functions import is_token_expired
 from rest_framework.generics import GenericAPIView
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
 from rest_framework.permissions import AllowAny
-from datetime import datetime, timedelta
-from django.conf import settings
+from django.db import transaction
 import logging
-
-
 logger = logging.getLogger('django')
 
 
 class UserRegistrationView(GenericAPIView):
     """
-    Takes email, first_name, last_name, password, token and activates the user.
-    User status is changed from Pending to Active.
+    Takes email, first_name, last_name, password, token and registers the user.
+    A new User is created and its associated(used) invitee is deleted.
 
     """
     USER_NOT_FOUND_ERROR_MESSAGE = 'Email does not exist in our invites system. You need to be invited to be able to register.'
-    USER_ALREADY_ACTIVE_ERROR_MESSAGE = 'User is already registered and Active'
     USER_TOKEN_MISMATCH_ERROR_MESSAGE = 'Invalid token. Token in request does not match the token generated for this user.'
-    TOKEN_NOT_FOUND_ERROR_MESSAGE = 'Invalid token. Token does not exist in our system.'
     INTERNAL_SERVER_ERROR_MESSAGE = 'Something went wrong : {0}'
     EXPECTED_KEY_NOT_PRESENT_IN_REQUEST = 'Invalid Request. Key not present in request : {0}'
     USER_TOKEN_EXPIRED_ERROR_MESSAGE = 'Expired token. Unable to register the user'
-    USER_ACTIVATED_SUCCESSFULLY = 'User Activated Succesfully'
+    USER_REGISTERED_SUCCESSFULLY = 'User Registered Successfully'
+    ERROR_CREATING_USERTEAM_ROLE = 'Error creating user team role'
+    ERROR_DELETING_USED_INVITEE = 'Error deleting used invitee'
+
     ERROR_STATUS = {
         USER_NOT_FOUND_ERROR_MESSAGE: status.HTTP_404_NOT_FOUND,
-        USER_ALREADY_ACTIVE_ERROR_MESSAGE: status.HTTP_400_BAD_REQUEST,
         USER_TOKEN_MISMATCH_ERROR_MESSAGE: status.HTTP_400_BAD_REQUEST,
-        TOKEN_NOT_FOUND_ERROR_MESSAGE: status.HTTP_404_NOT_FOUND,
         INTERNAL_SERVER_ERROR_MESSAGE: status.HTTP_500_INTERNAL_SERVER_ERROR,
         EXPECTED_KEY_NOT_PRESENT_IN_REQUEST: status.HTTP_400_BAD_REQUEST,
         USER_TOKEN_EXPIRED_ERROR_MESSAGE: status.HTTP_400_BAD_REQUEST
@@ -48,7 +44,15 @@ class UserRegistrationView(GenericAPIView):
             description="User Activated Successfully",
             examples={
                 "application/json": {
-                    "result": USER_ACTIVATED_SUCCESSFULLY
+                    "result": USER_REGISTERED_SUCCESSFULLY
+                }
+            }
+        ),
+        status.HTTP_500_INTERNAL_SERVER_ERROR: openapi.Response(
+            description="Internal Server Error",
+            examples={
+                "application/json": {
+                     'error': INTERNAL_SERVER_ERROR_MESSAGE
                 }
             }
         ),
@@ -64,62 +68,81 @@ class UserRegistrationView(GenericAPIView):
 
     @swagger_auto_schema(responses=post_response_schema)
     def post(self, request):
-        res_status = None
+        response_status = None
         error = None
-        req = request.data
+        request_data = request.data
+
         try:
-            user_queryset = User.objects.filter(email=req['email'])
-            result = self.__validate_request(user_queryset, req['token'])
-            if 'error' in result:
-                return Response({'error': result['error']}, status=result['status'])
-            user = result['user']
-            serializer = UserRegistrationSerializer(user, data={'email': req['email'], 'first_name': req['first_name'],
-                                                                'last_name': req['last_name'], 'password': req['password']})
-            if serializer.is_valid():
-                serializer.save()
-                self.__activate_user(user.userprofile)
-                self.__mark_token_used(result['token'])
-                res_status = status.HTTP_201_CREATED
+            invitee = Invitee.objects.get(email=request_data['email'])
+            request_token = request_data['token']
+            if (invitee.registration_token == request_token):
+                # email and token matched, check token expiration
+                if (not is_token_expired(self, request_token)):
+                    user_serializer = UserSerializer(data={'email': request_data['email'], 'username': request_data['email'],'first_name': request_data['first_name'],
+                                                                'last_name': request_data['last_name'], 'password': request_data['password']})
+                    # if the token is not expired and all the fields are valid,
+                    # create a new user, a new user-team-role and delete the invitee
+                    if user_serializer.is_valid():
+                        # creating txn savepoint
+                        sid = transaction.savepoint()
+                        user_obj = user_serializer.save()
+                        res_role_status = self.create_user_team_role(user_obj, invitee.role)
+                        res_delete_invitee = self.delete_invitee(invitee)
+
+                        if res_role_status and res_delete_invitee:
+                            # all well,commit data to the db
+                            transaction.savepoint_commit(sid)
+                            logger.info('UserRegistrationView: User data inserted successfully')
+                            response_status = status.HTTP_201_CREATED
+                        else:
+                            if not res_role_status:
+                                error = self.ERROR_CREATING_USERTEAM_ROLE
+                            if not res_delete_invitee:
+                                error = self.ERROR_DELETING_USED_INVITEE
+                            # something went wrong, don't commit data to db, rollback txn
+                            transaction.savepoint_rollback(sid)
+                            response_status = status.HTTP_500_INTERNAL_SERVER_ERROR
+                    else:
+                        # invalid data
+                        error = user_serializer.errors
+                        response_status = status.HTTP_400_BAD_REQUEST
+                else:
+                    # token expired
+                    error = self.USER_TOKEN_EXPIRED_ERROR_MESSAGE
+                    response_status = self.ERROR_STATUS[error]
             else:
-                error = serializer.errors
-                res_status = status.HTTP_400_BAD_REQUEST
+                # email and token mismatch. Invalid token for given email.
+                error = self.USER_TOKEN_MISMATCH_ERROR_MESSAGE
+                response_status = self.ERROR_STATUS[error]
+
+        except Invitee.DoesNotExist:
+            error = self.USER_NOT_FOUND_ERROR_MESSAGE
+            response_status = self.ERROR_STATUS[error]
         except KeyError as key_error:
             error = self.EXPECTED_KEY_NOT_PRESENT_IN_REQUEST.format(key_error)
-            res_status = self.ERROR_STATUS[self.EXPECTED_KEY_NOT_PRESENT_IN_REQUEST]
+            response_status = self.ERROR_STATUS[self.EXPECTED_KEY_NOT_PRESENT_IN_REQUEST]
         except Exception as e:
             error = self.INTERNAL_SERVER_ERROR_MESSAGE.format(e)
-            res_status = self.ERROR_STATUS[self.INTERNAL_SERVER_ERROR_MESSAGE]
-        if (error is None and res_status == status.HTTP_201_CREATED):
-            return Response({'result': self.USER_ACTIVATED_SUCCESSFULLY}, status=res_status)
-        return Response({'error': str(error)}, status=res_status)
+            response_status = self.ERROR_STATUS[self.INTERNAL_SERVER_ERROR_MESSAGE]
 
-    def __validate_request(self, user_queryset, request_token):
-        if not user_queryset.exists():
-            return self.__build_error_result(self.USER_NOT_FOUND_ERROR_MESSAGE)
-        user = user_queryset.first()
-        if not user.userprofile.is_pending():
-            return self.__build_error_result(self.USER_ALREADY_ACTIVE_ERROR_MESSAGE)
-        # check for valid unexpired registration token
-        token_datetime = datetime.strptime(request_token[-14:], '%Y%m%d%H%M%S')
-        now_datetime = datetime.now()
-        if not (now_datetime - timedelta(seconds=settings.REGISTRATION_LINK_EXPIRATION) <= token_datetime):
-            return self.__build_error_result(self.USER_TOKEN_EXPIRED_ERROR_MESSAGE)
-        token_qs = RegistrationToken.objects.filter(token=request_token, used=False)
-        if token_qs.exists():
-            token = token_qs.first()
-            if not (token and token.user.email == user.email):
-                return self.__build_error_result(self.USER_TOKEN_MISMATCH_ERROR_MESSAGE)
-        else:
-            return self.__build_error_result(self.TOKEN_NOT_FOUND_ERROR_MESSAGE)
-        return {'user': user, 'token': token}
+        if (error is None and response_status == status.HTTP_201_CREATED):
+            return Response({'result': self.USER_REGISTERED_SUCCESSFULLY}, status=response_status)
+        return Response({'error': str(error)}, status=response_status)
 
-    def __build_error_result(self, error):
-        return {'error': error, 'status': self.ERROR_STATUS[error]}
+    def create_user_team_role(self, user_obj, role):
+        try:
+            role_row = Role.objects.get(name=role)
+            userteam_row = User_Team(user=user_obj, role=role_row)
+            userteam_row.save()
+            return True
+        except Exception as e:
+            logger.error(f'AddMemberView:Error creating user team role : {e}')
+            return False
 
-    def __activate_user(self, userprofile):
-        userprofile.activate()
-        userprofile.save()
-
-    def __mark_token_used(self, token):
-        token.mark_as_used()
-        token.save()
+    def delete_invitee(self, invitee):
+        try:
+            invitee.delete()
+            return True
+        except Exception as e:
+            logger.error(f'UserRegistrationView:Error deleting used invitee : {e}')
+            return False


### PR DESCRIPTION
(\__/)
(='.'=)
(")_(")
To test test the PR  : 
### In InviteeView.py
 - on line 124 set message_sent = True and comment out the original code (so it won't fail when the email is not successfully sent)
### In Swagger
 - used POST/invitee/ to create a new invitee (because the other's token's have expired)
 - take the token from the 200 response body & the email from the invitee you created
 - go to POST/user/activate/ add the token & email to activate the user
 - then go to GET/users/ and make sure that the invitee you created/user activated is in that list
 - And if you really want to you can go to GET /user/{id}/ and pull up the user from the id listed in GET/users/
 
 <details>
<summary>Visual Testing Swagger</summary>

![Screenshot (357)](https://user-images.githubusercontent.com/67162265/225203668-8730375b-0590-4bd2-898c-2c89e2211e79.png)

just checking that the invitee is now in the invitee table

![Screenshot (358)](https://user-images.githubusercontent.com/67162265/225203939-f9c42555-8709-4c1c-9901-d51ff7fd44c1.png)

![Screenshot (359)](https://user-images.githubusercontent.com/67162265/225204798-63166add-78d3-42ee-9ba5-51ed5ddac7e3.png)

Getting to users to make sure ours has been added

![Screenshot (360)](https://user-images.githubusercontent.com/67162265/225205116-0a30b5a2-d8ec-408d-b38d-02fdb5d1f336.png)


![Screenshot (361)](https://user-images.githubusercontent.com/67162265/225205332-6f25cfc9-7e54-489a-9c17-7ed442721532.png)

Here we test to make sure that the new invitee is deleted after they are added to users

first we add the new invitee
![Screenshot (375)](https://user-images.githubusercontent.com/67162265/227319909-dc7c0ae8-214a-482a-803d-3bef0fd981f1.png)

here we can see the invitee has been added to the invitee table

![Screenshot (376)](https://user-images.githubusercontent.com/67162265/227320552-b69df6e4-e127-4863-92a2-bcaf011f8a7a.png)

Then we successfully activate the user

![Screenshot (377)](https://user-images.githubusercontent.com/67162265/227320952-583f6b8a-4a53-491e-bfcd-88dd9a9219da.png)

We then GET/invitee again to look at the invitee table and the test user is no longer there

![Screenshot (378)](https://user-images.githubusercontent.com/67162265/227321634-f902fc2d-8f4e-43ef-ac45-1d296028947c.png)

Then check the user to see if the appropriate role is added.

![Screenshot (380)](https://user-images.githubusercontent.com/67162265/227322606-e08e8fd9-7771-4792-a07e-c8e81d40f3dc.png)

</details>



The code in the UserRegistrationView looks to have been modified according to the flow Viri posted in the PR. 
 - It first checks for the invitee by email (ln 77)
 - then grabs the token from the request associated with the email (line 79) 
 - checks to see that the token is not expired(ln 81) 
 - uses the UserSerializer to validate the parameters (ln 82) 
 - creates a savepoint (ln 88)
 - then creates a new user record, adds the user to a team 
 - if these records are created, she creates a new savepoint (ln 95)
 - proceeds to delete the invitee (ln 91)

If any of these steps failed, the correct error message is thrown. 

The two functions that are added to UserRegistrationView, create_user_team_role & delete_invitee both work as intended, verified by the swagger screenshot. New users have a team role that correlates with the one entered and the invitees are deleted after the user is activated. *Note: I am unable to activate users unless they have a role 1.

The helper function works as intended it could be refactored to:


`def is_token_expired(self, registration_token):`
`return (datetime.now() - timedelta(seconds=settings.REGISTRATION_LINK_EXPIRATION) > datetime.strptime(registration_token[-14:], '%Y%m%d%H%M%S'))` 
But there is an argument for readability in the original code.


The last commit adding @transaction.atomic is a very clever and necessary one, to make sure that we don't delete an invitee without adding them as a user by only allowing the changes if the method doesn't throw an error.

The tests were mainly updated to include a director login to create new invitees & post users. A method to create an invitee instead of a user with a pending status so that we can later check to verify if the invitee was correctly added as a user and check to make sure the invitee was deleted. There were a few other minor changes made to tests_user_registration_view with regards to accurate error reporting. It looks like we are only testing one role. I am uncertain if we want to test roles besides volunteer. 
 